### PR TITLE
feat: show help by default when no command is provided

### DIFF
--- a/src/batoto_parser/cli.py
+++ b/src/batoto_parser/cli.py
@@ -16,6 +16,7 @@ app = typer.Typer(
     name="batoto-parser",
     help="Lightweight parser for Batoto-style manga sites",
     add_completion=False,
+    no_args_is_help=True, # Show help if no args are provided
 )
 console = Console()
 error_console = Console(stderr=True)


### PR DESCRIPTION
- Add no_args_is_help=True parameter to Typer app initialization
- Improves discoverability by displaying help automatically
- Aligns with standard CLI tool behavior (git, docker, npm, etc.)

Fixes #12