### PR TITLE
Docs: Added code of conduct markdown file using Contributor Covenant 2.1

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,54 @@
+# Contributor Covenant Code of Conduct 2.1
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in Batoto Parser a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive and healthy community.
+
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:-
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy toward other community members
+
+Examples of unacceptable behavior by participants include:-
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments and personal or political attacks
+- Public or private harassment
+- Publishing other's private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, or to temporarily or permanently ban any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+
+## Reporting Guidelines
+
+If you experience or witness any behavior that violates this Code of Conduct, please report it immediately by contacting:-
+
+**Email:** conduct@batoto-parser.dev  
+All complaints will be reviewed and investigated promptly and fairly.
+
+
+## Enforcement
+
+Instances of abusive, harassing or otherwise unacceptable behavior may be reported by contacting the project team at the above email address. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+
+## Scope
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing the project include using an official project email address, posting via an official social media account or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), which is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+## Supported Versions
+
+Batoto Parser actively maintains security updates for the following versions:
+
+| Version | Supported |
+| ------- | --------- |
+| main / latest release | ✅ Yes |
+
+Older versions may not receive security updates. Please ensure you are using
+the latest release from [PyPI](https://pypi.org/project/batoto-parser/).
+
+
+## Reporting a Vulnerability
+
+If you discover a security issue, **please don't open a public issue**.  
+Instead, report it responsibly using one of the following methods:-
+
+1. **Email:** security@batoto-parser.dev (replace with maintainers’ preferred email)  
+
+2. **Include the following information:**
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Any relevant logs, screenshots, or proof-of-concept code
+
+3. **Optional:** Suggested mitigation or fix
+
+We aim to respond you within **48 hrs**.
+
+
+## Response Process
+
+Once a security report is received:-
+
+1. Acknowledge receipt of the report promptly
+2. Assess the severity and potential impact
+3. Work on a private fix if required
+4. Coordinate disclosure with the reporter
+5. Release a patch or update along with a security advisory
+
+We request reporters **don't disclose** the issue publicly until a fix has been released.
+
+
+## Responsible Disclosure Guidelines
+
+- **Don't** exploit the vulnerability beyond verification.
+- Avoid public discussion until the maintainers release a patch.
+- Allow reasonable time for maintainers to investigate and fix issues.
+- Provide constructive details for reproducibility.
+
+
+## Project Scope
+
+This security policy applies to:-
+
+- The **Python library** in `batoto_parser/`
+- The **CLI tool** `batoto-parser`
+- All included scripts, examples, and documentation in this repository
+
+It **does not cover external dependencies** — please report vulnerabilities in dependent packages to their respective maintainers.
+
+
+## Acknowledgments
+
+We appreciate the contributions of security researchers and the community who help improve the safety of Batoto Parser.


### PR DESCRIPTION
### 

This Pull Request adds the CODE_OF_CONDUCT.md file to the Batoto Parser repository, establishing clear community guidelines or behavior and participation.

- Implements **Contributor Covenant 2.1** - the latest standard for open source projects.
- Defines standards of behavior, reporting guidelines and enforcement responsibilities.
- Clarifies the scope, covering the CLI, Python library, examples and all contributions.
- Provides a contact email for reporting issues (conduct@batoto-parser.dev)

### Importance

- Enhances professionalism and trust in the repository.
- Guides contributors on acceptable behavior and responsible reporting.
- Aligns with GitHub best practices for open-source projects.

### Related Issue

Part of the documentation issue #20 
