### PR TITLE
feat: implement GitHub Actions for CI (tests & linting)  (issue #11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[dev]
+        
+    - name: Lint with ruff
+      run: ruff check .
+      
+    - name: Check types with mypy
+      run: mypy src
+      
+    - name: Run tests with pytest
+      run: pytest


### PR DESCRIPTION
This PR addresses issue #11 by implementing a Continuous Integration (CI) pipeline using GitHub Actions. This ensures that all code contributions are automatically tested and checked for style and type consistency.

Changes

- Added [.github/workflows/ci.yml](cci:7://file:///c:/Users/sofia/SWOC/batoto-parser/.github/workflows/ci.yml:0:0-0:0)**:
- Triggers on `push` and `pull_request` to the `main` branch.
- Runs on a matrix of Python versions (3.8, 3.9, 3.10, 3.11, 3.12).
- Linting: Uses `ruff` for fast and comprehensive linting.
- Type Checking: Uses `mypy` for static type verification.
- Testing: Uses `pytest` to run all unit tests.

 Testing Performed

- Verified the workflow steps locally.
- Checked that `pytest` passes correctly.